### PR TITLE
add parameters for input/output/ref directories and dcm2niix flags

### DIFF
--- a/batch.sh
+++ b/batch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Fail if anything not planed to go wrong, goes wrong
+# Fail if anything not planned to go wrong, goes wrong
 set -eu
 
 PS4="Running: "
@@ -71,12 +71,12 @@ if [ ! -d "$refdir" ]; then
 fi
 
 if [ ! -d "$outdir" ]; then
- mkdir $outdir
+ mkdir $"outdir"
 fi
 
 if [ ! -z "$(ls $outdir)" ]; then
  echo "Cleaning output directory: $outdir"
- rm $outdir/*
+ rm $"outdir"/*
 fi
 
 # Convert images.

--- a/batch.sh
+++ b/batch.sh
@@ -30,6 +30,28 @@ fi
 indir=${basedir}/In
 outdir=${basedir}/Out
 refdir=${basedir}/Ref
+flags='-b y -z n -f "%p_%s"'
+
+help_message="usage: batch.sh -i <in dir> -o <out dir> -f <ref dir> -f <dcm2niix flags>\n
+default in dir : ${indir}\n
+default out dir: ${outdir}\n
+default ref dir: ${refdir}\n
+default dcm2niix flags: ${flags}"
+
+while getopts i:o:r:f:h option
+do 
+    case "${option}"
+        in
+        i)indir=${OPTARG};;
+        o)outdir=${OPTARG};;
+        r)refdir=${OPTARG};;
+        f)flags=${OPTARG};;
+        h)echo -e ${help_message}
+          exit 1;;
+        ?)echo -e ${help_message}
+          exit 1;;
+    esac
+done
 
 # Check inputs.
 exists $exenam ||
@@ -59,7 +81,7 @@ fi
 
 # Convert images.
 set -x
-$exenam -b y -z n -f "%p_%s" -o "$outdir" "$indir"
+$exenam ${flags} -o "$outdir" "$indir"
 set +x
 
 # Validate JSON.

--- a/batch.sh
+++ b/batch.sh
@@ -71,12 +71,12 @@ if [ ! -d "$refdir" ]; then
 fi
 
 if [ ! -d "$outdir" ]; then
- mkdir $"outdir"
+ mkdir ${outdir}
 fi
 
 if [ ! -z "$(ls $outdir)" ]; then
  echo "Cleaning output directory: $outdir"
- rm $"outdir"/*
+ rm ${outdir}/*
 fi
 
 # Convert images.


### PR DESCRIPTION
Added parameters for input/output/ref directories and dcm2niix flags. If not included, defaults will be used. Also added a help message and put some missing quotes around $outdir in a couple of spots.